### PR TITLE
Add route to resend verification email

### DIFF
--- a/src/lib/api/apiRoutes.ts
+++ b/src/lib/api/apiRoutes.ts
@@ -17,6 +17,10 @@ export const apiRoutes = {
       href: "/api/account/send-reset-password-email",
       method: "POST",
     },
+    resendVerificationEmail: {
+      href: "/api/account/send-verification-email",
+      method: "POST",
+    },
     changePassword: {
       href: "/api/account/changePassword",
       method: "POST",


### PR DESCRIPTION
After migrating from Vulcan Meteor, user accounts don't appear to be verified (I was adding users to a custom `verifiedEmail` group).
So I need a way to resend the verification, not only send on signup.

This might also be useful when someone has lost the original verification email somehow, or just can't find it.

I tried resending verification with a button click, and it worked:

```
const body = {
          email: 'myemail@gmail.com',
        };
        try {
          const res = await fetch(apiRoutes.account.resendVerificationEmail.href, {
            method: "POST",
            headers: { "Content-Type": "application/json" },
            body: JSON.stringify(body),
          });
          if (res.status !== 200) {
            const msg = await res.text();
            console.log(msg)
          } else {
            // setSuccessMsg(
            //   "If this email exists in our database, we will send you an email a new verification email."
            // );
          }
        } catch (error) {
          console.error("An unexpected error occurred:", error);
          // setErrorMsg(error.message);
        }
``` 